### PR TITLE
fix config module not found

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,9 @@ dev = [
     "mypy>=0.900",
 ]
 
-[tool.setuptools]
-packages = ["docex"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["docex*"]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
Ensures all submodules are properly included when the package is installed.