### PR TITLE
changed package auto-discovery for install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,8 @@ dev = [
     "mypy>=0.900",
 ]
 
-[tool.setuptools.packages.find]
-where = ["."]
-include = ["docex*"]
+[tool.setuptools]
+packages = { find = {} }
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
running `pip install docex` then `docex init` gives this, even after the previous fix:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\yanni\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\Scripts\DocEX.exe\__main__.py", line 4, in <module>
  File "C:\Users\yanni\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\docex\__init__.py", line 32, in <module>
    from .docCore import DocEX
  File "C:\Users\yanni\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\docex\docCore.py", line 6, in <module>
    from docex.config.docflow_config import DocFlowConfig
ModuleNotFoundError: No module named 'docex.config.docflow_config'
```

instead of mixing manual/automatic package discovery, i switched it to auto-discover all (including nested) packages. this fixed the initial `docex init` issue.