### PR TITLE
fix the cli init issue. replace docflow to docex

### DIFF
--- a/docex/cli.py
+++ b/docex/cli.py
@@ -90,8 +90,8 @@ def init(config, force, db_type, db_path, db_host, db_port, db_name, db_user, db
         
         click.echo(f'DEBUG: Config before setup: {user_config}')
         
-        # Initialize DocFlow
-        DocFlow.setup(**user_config)
+        # Initialize Docex
+        DocEX.setup(**user_config)
         
         # Save configuration
         config_path = Path.home() / '.docflow' / 'config.yaml'
@@ -113,8 +113,8 @@ def init(config, force, db_type, db_path, db_host, db_port, db_name, db_user, db
         with open(config_path, 'w') as f:
             yaml.dump(safe_config, f, default_flow_style=False, sort_keys=False)
         
-        # Create DocFlow instance for verification
-        docflow = DocFlow()
+        # Create DocEx instance for verification
+        docex = DocEX()
         
         # Verify storage setup
         storage_path = Path(user_config['storage']['filesystem']['path'])


### PR DESCRIPTION
## Issue
After renaming the `DocFlow` to `DocEX`, the import and the reference was not updated accordingly, which caused the error when running `docex init`.

### Test
running `python3 -m docex.cli init` locally and verified the fix.

```
(venv) ➜  DocEX git:(main) ✗ python3 -m docex.cli init
Storage path 'storage/docflow' is relative. It will be resolved relative to the current working directory.
DocEX is already initialized. Do you want to reinitialize? This will drop all existing data. [y/N]: y
Removing existing database...
Removed existing database at docflow.db
DEBUG: Config before setup: {'database': {'type': 'sqlite', 'sqlite': {'path': PosixPath('docflow.db')}, 'postgres': {'host': 'localhost', 'port': 5432, 'database': 'docflow', 'user': 'postgres', 'password': 'postgres'}, 'echo': True, 'pool_size': 5, 'max_overflow': 10, 'pool_timeout': 30, 'pool_recycle': 3600}, 'app': {'name': 'DocFlow', 'version': '1.0.0', 'debug': True, 'log_level': 'DEBUG'}, 'storage': {'type': 'filesystem', 'filesystem': {'path': 'storage/docflow'}}, 'logging': {'level': 'DEBUG', 'file': 'docflow.log'}}

Storage Setup:
  Path: /Users/sweetprince/workplace/DocEX/storage/docflow
  Exists: True
  Permissions: 755
  Owner: sweetprince

Database Setup:
  Type: sqlite
  Path: /Users/sweetprince/workplace/DocEX/docflow.db
  Exists: True
  Size: 114688 bytes
  Last Modified: 2025-05-27 23:21:38.322211
  All required tables exist

Configuration:
database:
  type: sqlite
  sqlite:
    path: !!python/object/apply:pathlib._local.PosixPath
    - docflow.db
  postgres:
    host: localhost
    port: 5432
    database: docflow
    user: postgres
    password: postgres
  echo: true
  pool_size: 5
  max_overflow: 10
  pool_timeout: 30
  pool_recycle: 3600
app:
  name: DocFlow
  version: 1.0.0
  debug: true
  log_level: DEBUG
storage:
  type: filesystem
  filesystem:
    path: storage/docflow
logging:
  level: DEBUG
  file: docflow.log


DocEX initialized successfully!
```