### PR TITLE
Add BasketRecord and DocumentRecord typed models for lightweight reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,14 @@ hello_file.write_text('Hello scos.ai!')
 # Add the document to the basket
 doc = basket.add(str(hello_file))
 
-# Print document details
-print(doc.get_details())
+# Print document details — access fields as attributes, e.g. record.name, record.status
+details = doc.get_details()
+print(details.name, details.status, details.created_at)
 
 hello_file.unlink()
 ```
+
+These methods return typed `BasketRecord` and `DocumentRecord` instances instead of plain dictionaries.
 
 ### Security and Multi-Tenancy
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -50,6 +50,7 @@
 - `DocEXPathResolver` for unified path resolution
 - `ConfigResolver` for tenant-aware configuration resolution
 - `SchemaResolver` for database schema resolution
+- Added BasketRecord and DocumentRecord typed models for lightweight metadata reads (#4)
 
 ### 📚 Documentation
 

--- a/docex/__init__.py
+++ b/docex/__init__.py
@@ -29,9 +29,10 @@ Basic usage:
     print(DocEX.get_metadata_keys())
 """
 
-from docex.docCore import DocEX  # Updated to use docCore instead of docex
 from docex.config.docex_config import DocEXConfig  # Updated import
+from docex.docCore import DocEX  # Updated to use docCore instead of docex
+from docex.models.records import BasketRecord, DocumentRecord
 
-__all__ = ['DocEX', 'DocEXConfig']
+__all__ = ['DocEX', 'DocEXConfig', 'BasketRecord', 'DocumentRecord']
 
 __version__ = '2.8.4'

--- a/docex/docCore.py
+++ b/docex/docCore.py
@@ -1,18 +1,21 @@
+from __future__ import annotations
+
 import logging
-import os
-from typing import Dict, Any, Optional, List
 from pathlib import Path
+from typing import Any, Dict, List, Optional
+
 import yaml
+from sqlalchemy import inspect, text
+
 from docex.config.docex_config import DocEXConfig
+from docex.context import UserContext
 from docex.db.connection import Database
+from docex.db.models import Base
 from docex.docbasket import DocBasket
 from docex.models.metadata_keys import MetadataKey
-from docex.db.models import Base
+from docex.models.records import BasketRecord
 from docex.transport.models import Base as TransportBase
 from docex.transport.transport_result import TransportResult
-from docex.context import UserContext
-from sqlalchemy import inspect, text
-from datetime import datetime, timezone
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -327,9 +330,9 @@ class DocEX:
             ValueError: If tenant does not exist in registry
         """
         try:
-            from docex.db.tenant_registry_model import TenantRegistry
-            from docex.db.connection import Database
             from docex.config.docex_config import DocEXConfig
+            from docex.db.connection import Database
+            from docex.db.tenant_registry_model import TenantRegistry
             
             # Get database connection for tenant registry query
             # Use bootstrap tenant's database for v3.0, or default for v2.x
@@ -485,8 +488,6 @@ class DocEX:
                     return True
                 else:
                     # Ensure all models are imported
-                    import docex.db.models
-                    import docex.transport.models
                     db = Database()
                     
                     # Drop all tables first (only if we have permission)
@@ -698,9 +699,11 @@ class DocEX:
             >>> # List all baskets sorted by name
             >>> baskets = docex.list_baskets(order_by='name', order_desc=False)
         """
-        from docex.db.models import DocBasket as DocBasketModel
-        from sqlalchemy import select
         import json
+
+        from sqlalchemy import select
+
+        from docex.db.models import DocBasket as DocBasketModel
         
         with self.db.session() as session:
             query = select(DocBasketModel)
@@ -765,34 +768,39 @@ class DocEX:
         offset: Optional[int] = None,
         order_by: Optional[str] = None,
         order_desc: bool = False
-    ) -> List[Dict[str, Any]]:
+    ) -> List[BasketRecord]:
         """
         Efficiently list baskets with selected metadata columns.
-        
-        This method returns lightweight dictionaries instead of full DocBasket instances,
-        avoiding object instantiation overhead and providing better performance for
-        listing operations where you don't need full basket functionality.
-        
+
+        This method returns typed :class:`~docex.models.records.BasketRecord`
+        instances instead of full DocBasket objects, avoiding instantiation
+        overhead and providing better performance for listing operations where
+        full basket functionality is not required.
+
         **Performance Benefits:**
         - No DocBasket object instantiation (saves memory and CPU)
         - No path_helper, document_manager, or storage_service initialization
         - Direct column projection from database (index-only scans possible)
         - Faster for large result sets
-        
+
         Args:
             columns: List of column names to include in results.
-                    Default: ['id', 'name', 'status', 'created_at', 'updated_at']
-                    Available: 'id', 'name', 'description', 'status', 'created_at', 'updated_at', 'document_count'
-                    Note: 'document_count' requires a JOIN query and may be slower for large datasets
+                Default: ['id', 'name', 'status', 'created_at', 'updated_at']
+                Available: 'id', 'name', 'description', 'status',
+                'created_at', 'updated_at', 'document_count'. Note:
+                'document_count' requires a JOIN query and may be slower
+                for large datasets.
             filters: Optional dictionary of filters (e.g., {'status': 'active'})
             limit: Maximum number of results to return (for pagination)
             offset: Number of results to skip (for pagination)
-            order_by: Field to sort by ('created_at', 'name', 'updated_at', 'status', 'document_count')
+            order_by: Field to sort by ('created_at', 'name', 'updated_at',
+                'status', 'document_count')
             order_desc: If True, sort in descending order
-            
+
         Returns:
-            List of dictionaries containing selected basket fields
-            
+            List of :class:`~docex.models.records.BasketRecord` instances
+            containing the selected basket fields.
+
         Example:
             >>> # Get lightweight basket list with basic info
             >>> baskets = docex.list_baskets_with_metadata(
@@ -800,32 +808,27 @@ class DocEX:
             ...     filters={'status': 'active'},
             ...     limit=100
             ... )
-            >>> # Returns:
-            >>> # [
-            >>> #     {'id': 'bas_123', 'name': 'invoice_raw', 'status': 'active', 'created_at': '2024-01-01T00:00:00'},
-            >>> #     ...
-            >>> # ]
-            
+            >>> basket = baskets[0]
+            >>> print(basket.name, basket.status, basket.created_at)
+
             >>> # Get baskets with document count
             >>> baskets = docex.list_baskets_with_metadata(
             ...     columns=['id', 'name', 'document_count'],
             ...     order_by='document_count',
             ...     order_desc=True
             ... )
-            >>> # Returns:
-            >>> # [
-            >>> #     {'id': 'bas_123', 'name': 'invoice_raw', 'document_count': 42},
-            >>> #     ...
-            >>> # ]
-            
+            >>> print(baskets[0].name, baskets[0].document_count)
+
             >>> # Get basket IDs and names only (fastest)
             >>> baskets = docex.list_baskets_with_metadata(
             ...     columns=['id', 'name'],
             ...     order_by='name'
             ... )
         """
-        from docex.db.models import DocBasket as DocBasketModel, Document as DocumentModel
-        from sqlalchemy import select, func, outerjoin
+        from sqlalchemy import func, select
+
+        from docex.db.models import DocBasket as DocBasketModel
+        from docex.db.models import Document as DocumentModel
         
         # Default columns if not specified
         if columns is None:
@@ -925,24 +928,20 @@ class DocEX:
             # Execute query and convert to dictionaries
             results = session.execute(query).all()
             
-            # Convert to list of dictionaries
+            # Convert to list of BasketRecord instances
             baskets = []
             for row in results:
-                basket_dict = {}
+                record_kwargs: Dict[str, Any] = {}
                 row_index = 0
                 for col in columns:
                     if col in column_map:
-                        value = row[row_index]
-                        # Convert datetime to ISO format string for JSON serialization
-                        if hasattr(value, 'isoformat'):
-                            value = value.isoformat()
-                        basket_dict[col] = value
+                        record_kwargs[col] = row[row_index]
                         row_index += 1
                     elif col == 'document_count':
                         # document_count is the last column in the row
                         value = row[-1] if include_document_count else 0
-                        basket_dict[col] = int(value) if value is not None else 0
-                baskets.append(basket_dict)
+                        record_kwargs[col] = int(value) if value is not None else 0
+                baskets.append(BasketRecord(**record_kwargs))
             
             logger.debug(f"Retrieved {len(baskets)} baskets with metadata (columns: {columns})")
             return baskets
@@ -1008,7 +1007,7 @@ class DocEX:
         can_delete: bool = False,
         enabled: bool = True,
         other_party: Optional[Dict[str, str]] = None
-    ) -> 'Route':
+    ) -> "Route":  # noqa: F821
         """Create a new transport route
         
         Args:
@@ -1026,14 +1025,16 @@ class DocEX:
         Returns:
             Created route instance
         """
-        from docex.transport.config import (
-            RouteConfig, OtherParty, TransportType,
-            LocalTransportConfig, SFTPTransportConfig, HTTPTransportConfig
-        )
-        from docex.transport.transporter_factory import TransporterFactory
-        from docex.transport.models import Route as RouteModel
-        from docex.db.connection import Database
         from uuid import uuid4
+
+        from docex.transport.config import (
+            LocalTransportConfig,
+            OtherParty,
+            RouteConfig,
+            TransportType,
+        )
+        from docex.transport.models import Route as RouteModel
+        from docex.transport.transporter_factory import TransporterFactory
         
         # Create transport config based on type
         transport_type_enum = TransportType(transport_type)
@@ -1109,7 +1110,7 @@ class DocEX:
         route.db = self.db
         return route
     
-    def get_route(self, name: str) -> Optional['Route']:
+    def get_route(self, name: str) -> Optional["Route"]:  # noqa: F821
         """Get a route by name
         
         Args:
@@ -1137,7 +1138,7 @@ class DocEX:
         purpose: Optional[str] = None,
         transport_type: Optional[str] = None,
         enabled: Optional[bool] = None
-    ) -> List['Route']:
+    ) -> List["Route"]:  # noqa: F821
         """List routes with optional filters
         
         Args:

--- a/docex/document.py
+++ b/docex/document.py
@@ -12,6 +12,7 @@ from sqlalchemy import text
 from docex.config.config_manager import ConfigManager
 from docex.db.connection import Database
 from docex.db.models import Operation
+from docex.models.records import DocumentRecord
 from docex.services.metadata_service import MetadataService
 from docex.services.storage_service import StorageService
 from docex.transport.models import RouteOperation
@@ -119,20 +120,26 @@ class Document:
         """Instance method version of get_content for compatibility."""
         return Document._get_content_static(self, mode)
     
-    def get_details(self) -> Dict[str, Any]:
-        """Get document details"""
-        return {
-            "id": self.id,
-            "name": self.name,
-            "path": self.path,
-            "content_type": self.content_type,
-            "document_type": self.document_type,
-            "size": self.size,
-            "checksum": self.checksum,
-            "status": self.status,
-            "created_at": self.created_at,
-            "updated_at": self.updated_at
-        }
+    def get_details(self) -> DocumentRecord:
+        """Get document details.
+
+        Returns:
+            A :class:`~docex.models.records.DocumentRecord` containing the
+            core document fields. Use ``.model_dump()`` if a plain dict is
+            required for serialisation.
+        """
+        return DocumentRecord(
+            id=self.id,
+            name=self.name,
+            path=self.path,
+            content_type=self.content_type,
+            document_type=self.document_type,
+            size=self.size,
+            checksum=self.checksum,
+            status=self.status,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )
 
     def get_metadata(self) -> Dict[str, Any]:
         """Get all metadata for this document from the database as direct values."""

--- a/docex/models/records.py
+++ b/docex/models/records.py
@@ -1,0 +1,87 @@
+"""
+Typed record models for lightweight DocEX reads.
+
+These models provide stable, typed alternatives to the raw dictionaries
+previously returned by metadata-first APIs such as
+``DocEX.list_baskets_with_metadata`` and ``Document.get_details``.
+
+Consumers that only need metadata should use these records rather than
+constructing full ``DocBasket`` or ``Document`` objects, which initialise
+storage, path helpers, and service layers that are unnecessary for
+read-only inspection.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class BasketRecord(BaseModel):
+    """Lightweight read-only record for a document basket.
+
+    Returned by :meth:`DocEX.list_baskets_with_metadata`.
+    Fields map 1-to-1 with the columns available in that method.
+
+    All fields are ``Optional`` with ``None`` defaults because
+    ``list_baskets_with_metadata`` accepts an arbitrary ``columns`` subset;
+    any column not requested will not be present in the constructor call.
+
+    Attributes:
+        id: Basket primary key (``bas_<uuid>`` format).
+        name: Human-readable basket name.
+        description: Optional free-text description of the basket.
+        status: Lifecycle status, e.g. ``'active'``.
+        created_at: UTC timestamp when the basket was created.
+        updated_at: UTC timestamp of the last basket update.
+        document_count: Number of documents in the basket. Only populated
+            when ``'document_count'`` is included in the ``columns``
+            argument; ``None`` otherwise.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+    status: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    document_count: Optional[int] = None
+
+
+class DocumentRecord(BaseModel):
+    """Lightweight read-only record for a document.
+
+    Returned by :meth:`Document.get_details` and document list/search
+    methods. Fields map 1-to-1 with the keys in the existing
+    ``get_details()`` dict.
+
+    Attributes:
+        id: Document primary key (``doc_<uuid>`` format).
+        name: File name of the document.
+        path: Storage path relative to the basket's storage root.
+        content_type: MIME type of the document. ``None`` when the type
+            could not be determined.
+        document_type: Category of the document, e.g. ``'file'``.
+        size: Size of the document in bytes. ``None`` when not yet
+            computed.
+        checksum: SHA-256 hex digest of the document content.
+        status: Lifecycle status, e.g. ``'active'``.
+        created_at: UTC timestamp when the document was ingested.
+        updated_at: UTC timestamp of the last document update.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    name: str
+    path: str
+    content_type: Optional[str] = None
+    document_type: str
+    size: Optional[int] = None
+    checksum: str
+    status: str
+    created_at: datetime
+    updated_at: datetime

--- a/scripts/test/test_performance_improvements.py
+++ b/scripts/test/test_performance_improvements.py
@@ -122,10 +122,10 @@ def test_basket_listing_with_metadata(docex: DocEX, verbose: bool = False):
         if verbose:
             print("\nBaskets with document counts:")
             for basket in baskets_metadata:
-                print(f"  - {basket['name']} (ID: {basket['id'][:20]}...): {basket['document_count']} documents")
+                print(f"  - {basket.name} (ID: {basket.id[:20]}...): {basket.document_count} documents")
         else:
             if baskets_metadata:
-                print(f"  Example: {baskets_metadata[0]['name']} has {baskets_metadata[0]['document_count']} documents")
+                print(f"  Example: {baskets_metadata[0].name} has {baskets_metadata[0].document_count} documents")
         
         # Test 1.2: Get lightweight basket list (IDs and names only)
         print("\n1.2: Getting lightweight basket list (IDs and names only)...")
@@ -139,14 +139,14 @@ def test_basket_listing_with_metadata(docex: DocEX, verbose: bool = False):
         if verbose and baskets_lightweight:
             print("  First 5 baskets:")
             for basket in baskets_lightweight[:5]:
-                print(f"    - {basket['name']} (ID: {basket['id']})")
+                print(f"    - {basket.name} (ID: {basket.id})")
         
         # Test 1.3: Lazy instantiation pattern
         print("\n1.3: Testing lazy instantiation pattern...")
         if baskets_metadata:
             # Get ID from metadata (no object instantiation)
-            selected_basket_id = baskets_metadata[0]['id']
-            selected_basket_name = baskets_metadata[0]['name']
+            selected_basket_id = baskets_metadata[0].id
+            selected_basket_name = baskets_metadata[0].name
             
             print(f"  Selected basket from metadata: {selected_basket_name} (ID: {selected_basket_id[:20]}...)")
             
@@ -187,10 +187,10 @@ def test_document_listing_with_metadata(docex: DocEX, verbose: bool = False):
         # Find a basket that has documents
         basket = None
         for basket_info in baskets_with_docs:
-            if basket_info.get('document_count', 0) > 0:
-                basket_id = basket_info['id']
+            if (basket_info.document_count or 0) > 0:
+                basket_id = basket_info.id
                 basket = docex.get_basket(basket_id=basket_id)
-                print(f"Using basket: {basket.name} (ID: {basket.id[:20]}...) with {basket_info['document_count']} documents")
+                print(f"Using basket: {basket.name} (ID: {basket.id[:20]}...) with {basket_info.document_count} documents")
                 break
         
         # If no baskets with documents, create a test basket with documents
@@ -307,10 +307,10 @@ def test_performance_comparison(docex: DocEX, verbose: bool = False):
         # Find a basket that has documents
         basket_with_docs = None
         for basket_info in baskets_with_docs:
-            if basket_info.get('document_count', 0) > 0:
-                basket_id = basket_info['id']
+            if (basket_info.document_count or 0) > 0:
+                basket_id = basket_info.id
                 basket_with_docs = docex.get_basket(basket_id=basket_id)
-                print(f"  Using basket '{basket_info['name']}' with {basket_info['document_count']} documents")
+                print(f"  Using basket '{basket_info.name}' with {basket_info.document_count} documents")
                 break
         
         if not basket_with_docs:
@@ -380,7 +380,7 @@ def test_document_count_feature(docex: DocEX, verbose: bool = False):
         if baskets_with_counts:
             print("\nBaskets sorted by document count (descending):")
             for i, basket in enumerate(baskets_with_counts, 1):
-                print(f"  {i}. {basket['name']}: {basket['document_count']} documents")
+                print(f"  {i}. {basket.name}: {basket.document_count} documents")
         
         # Test 4.2: Filter baskets with document counts
         print("\n4.2: Filtering baskets with document counts...")
@@ -396,7 +396,7 @@ def test_document_count_feature(docex: DocEX, verbose: bool = False):
         if baskets_filtered:
             print("  Baskets with fewest documents first:")
             for basket in baskets_filtered:
-                print(f"    - {basket['name']}: {basket['document_count']} documents")
+                print(f"    - {basket.name}: {basket.document_count} documents")
         
         return True
         

--- a/tests/test_docflow.py
+++ b/tests/test_docflow.py
@@ -227,11 +227,11 @@ class TestDocEX(unittest.TestCase):
         # Get document details
         details = doc.get_details()
         self.assertIsNotNone(details)
-        self.assertEqual(details['name'], 'test.txt')
-        self.assertEqual(details['content_type'], 'text/plain')
-        self.assertEqual(details['status'], 'RECEIVED')
-        self.assertIn('created_at', details)
-        self.assertIn('updated_at', details)
+        self.assertEqual(details.name, 'test.txt')
+        self.assertEqual(details.content_type, 'text/plain')
+        self.assertEqual(details.status, 'RECEIVED')
+        self.assertIsNotNone(details.created_at)
+        self.assertIsNotNone(details.updated_at)
         
         # Get document content
         content = doc.get_content()

--- a/tests/test_docflow_postgres.py
+++ b/tests/test_docflow_postgres.py
@@ -274,11 +274,11 @@ class TestDocEXPostgres(unittest.TestCase):
         # Get document details
         details = doc.get_details()
         self.assertIsNotNone(details)
-        self.assertEqual(details['name'], 'test.txt')
-        self.assertEqual(details['content_type'], 'text/plain')
-        self.assertEqual(details['status'], 'RECEIVED')
-        self.assertIn('created_at', details)
-        self.assertIn('updated_at', details)
+        self.assertEqual(details.name, 'test.txt')
+        self.assertEqual(details.content_type, 'text/plain')
+        self.assertEqual(details.status, 'RECEIVED')
+        self.assertIsNotNone(details.created_at)
+        self.assertIsNotNone(details.updated_at)
         
         # Get document content
         content = doc.get_content()

--- a/tests/test_docflow_usage.py
+++ b/tests/test_docflow_usage.py
@@ -95,4 +95,4 @@ class TestDocEXUsage(unittest.TestCase):
         
         # 5. Verify document status
         doc_status = doc.get_details()
-        self.assertEqual(doc_status["status"], "SENT") 
+        self.assertEqual(doc_status.status, "SENT")

--- a/tests/test_lazy_storage_read_paths.py
+++ b/tests/test_lazy_storage_read_paths.py
@@ -119,11 +119,13 @@ def test_list_basket_reads_do_not_initialize_storage(populated_basket, monkeypat
     basket_rows = docex.list_baskets_with_metadata(columns=["id", "name"])
 
     matching_baskets = [listed for listed in baskets if listed.id == basket.id]
-    matching_rows = [row for row in basket_rows if row["id"] == basket.id]
+    matching_rows = [row for row in basket_rows if row.id == basket.id]
 
     assert len(matching_baskets) == 1
     assert matching_baskets[0]._storage_service is None
-    assert matching_rows == [{"id": basket.id, "name": basket.name}]
+    assert len(matching_rows) == 1
+    assert matching_rows[0].id == basket.id
+    assert matching_rows[0].name == basket.name
 
 
 def test_doccore_lightweight_basket_listing_skips_docbasket_instantiation(
@@ -143,7 +145,7 @@ def test_doccore_lightweight_basket_listing_skips_docbasket_instantiation(
     monkeypatch.setattr(DocBasket, "__init__", tracked_init)
 
     basket_rows = docex.list_baskets_with_metadata(columns=["id", "name"])
-    assert any(row["id"] == basket.id for row in basket_rows)
+    assert any(row.id == basket.id for row in basket_rows)
     assert constructed_baskets == []
 
     baskets = docex.list_baskets()

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,0 +1,273 @@
+"""
+Unit tests for BasketRecord and DocumentRecord typed models.
+
+All tests are fully isolated — no real database connections are made.
+The session layer is mocked at the ``Database`` class level so that
+``list_baskets_with_metadata`` can be exercised without any external
+infrastructure.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from docex import DocEX, BasketRecord, DocumentRecord
+from docex.document import Document
+
+
+# ---------------------------------------------------------------------------
+# Helpers / shared fixtures
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def reset_docex_singleton():
+    """Ensure the DocEX singleton is cleared before and after every test."""
+    DocEX._instance = None
+    yield
+    DocEX._instance = None
+
+
+@pytest.fixture
+def docex_with_mock_db():
+    """Yield a (DocEX instance, mock_db) pair with no real DB calls.
+
+    ``Database`` is patched at import time in ``docex.docCore`` so that
+    ``DocEX.__init__`` stores a ``MagicMock`` as ``self.db``.
+    """
+    with (
+        patch("docex.docCore.DocEX.is_initialized", return_value=True),
+        patch("docex.docCore.DocEXConfig") as mock_config_cls,
+        patch("docex.docCore.Database") as mock_db_cls,
+    ):
+        mock_config = MagicMock()
+        mock_config.get.return_value = {}
+        mock_config_cls.return_value = mock_config
+
+        mock_db = MagicMock()
+        mock_db_cls.return_value = mock_db
+
+        instance = DocEX()
+        yield instance, mock_db
+
+
+@pytest.fixture
+def sample_document():
+    """Return a ``Document`` instance constructed from known values."""
+    return Document(
+        id="doc_abc123",
+        name="invoice.pdf",
+        path="baskets/inv/invoice.pdf",
+        content_type="application/pdf",
+        document_type="file",
+        size=4096,
+        checksum="deadbeef" * 8,
+        status="active",
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+# ---------------------------------------------------------------------------
+# BasketRecord — instantiation and immutability
+# ---------------------------------------------------------------------------
+
+
+def test_basket_record_instantiation():
+    """BasketRecord stores every field exactly as supplied."""
+    record = BasketRecord(
+        id="bas_001",
+        name="invoices",
+        description="Raw invoice drop zone",
+        status="active",
+        created_at=NOW,
+        updated_at=NOW,
+        document_count=7,
+    )
+
+    assert record.id == "bas_001"
+    assert record.name == "invoices"
+    assert record.description == "Raw invoice drop zone"
+    assert record.status == "active"
+    assert record.created_at == NOW
+    assert record.updated_at == NOW
+    assert record.document_count == 7
+
+
+def test_basket_record_is_frozen():
+    """Mutating any field on a BasketRecord must raise TypeError."""
+    record = BasketRecord(id="bas_001", name="invoices")
+
+    with pytest.raises((TypeError, ValidationError)):
+        record.name = "something_else"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# DocumentRecord — instantiation and immutability
+# ---------------------------------------------------------------------------
+
+
+def test_document_record_instantiation():
+    """DocumentRecord stores every field exactly as supplied."""
+    record = DocumentRecord(
+        id="doc_abc123",
+        name="invoice.pdf",
+        path="baskets/inv/invoice.pdf",
+        content_type="application/pdf",
+        document_type="file",
+        size=4096,
+        checksum="deadbeef" * 8,
+        status="active",
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+    assert record.id == "doc_abc123"
+    assert record.name == "invoice.pdf"
+    assert record.path == "baskets/inv/invoice.pdf"
+    assert record.content_type == "application/pdf"
+    assert record.document_type == "file"
+    assert record.size == 4096
+    assert record.checksum == "deadbeef" * 8
+    assert record.status == "active"
+    assert record.created_at == NOW
+    assert record.updated_at == NOW
+
+
+def test_document_record_is_frozen():
+    """Mutating any field on a DocumentRecord must raise TypeError."""
+    record = DocumentRecord(
+        id="doc_abc123",
+        name="invoice.pdf",
+        path="baskets/inv/invoice.pdf",
+        content_type="application/pdf",
+        document_type="file",
+        size=4096,
+        checksum="deadbeef" * 8,
+        status="active",
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+    with pytest.raises((TypeError, ValidationError)):
+        record.name = "other.pdf"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Integration: list_baskets_with_metadata returns typed records
+# ---------------------------------------------------------------------------
+
+
+def test_list_baskets_with_metadata_returns_typed_records(docex_with_mock_db):
+    """list_baskets_with_metadata must return BasketRecord instances."""
+    instance, mock_db = docex_with_mock_db
+
+    # Simulate a single DB row containing (id, name)
+    fake_row = ("bas_test001", "test_basket")
+    mock_session = MagicMock()
+    mock_session.execute.return_value.all.return_value = [fake_row]
+    mock_db.session.return_value.__enter__.return_value = mock_session
+    mock_db.session.return_value.__exit__.return_value = False
+
+    results = instance.list_baskets_with_metadata(columns=["id", "name"])
+
+    assert len(results) == 1
+    assert isinstance(results[0], BasketRecord)
+    assert results[0].id == "bas_test001"
+    assert results[0].name == "test_basket"
+
+
+# ---------------------------------------------------------------------------
+# Integration: Document.get_details returns a typed record
+# ---------------------------------------------------------------------------
+
+
+def test_get_details_returns_typed_record(sample_document):
+    """Document.get_details must return a DocumentRecord with matching fields."""
+    result = sample_document.get_details()
+
+    assert isinstance(result, DocumentRecord)
+    assert result.id == "doc_abc123"
+    assert result.name == "invoice.pdf"
+    assert result.path == "baskets/inv/invoice.pdf"
+    assert result.content_type == "application/pdf"
+    assert result.document_type == "file"
+    assert result.size == 4096
+    assert result.checksum == "deadbeef" * 8
+    assert result.status == "active"
+    assert result.created_at == NOW
+    assert result.updated_at == NOW
+
+
+# ---------------------------------------------------------------------------
+# model_dump
+# ---------------------------------------------------------------------------
+
+
+def test_basket_record_model_dump():
+    """BasketRecord.model_dump() returns a plain dict with all field keys."""
+    record = BasketRecord(
+        id="bas_001",
+        name="invoices",
+        description=None,
+        status="active",
+        created_at=NOW,
+        updated_at=NOW,
+        document_count=3,
+    )
+
+    dumped = record.model_dump()
+
+    assert isinstance(dumped, dict)
+    assert set(dumped.keys()) == {
+        "id",
+        "name",
+        "description",
+        "status",
+        "created_at",
+        "updated_at",
+        "document_count",
+    }
+    assert dumped["id"] == "bas_001"
+    assert dumped["document_count"] == 3
+    assert dumped["description"] is None
+
+
+def test_document_record_model_dump():
+    """DocumentRecord.model_dump() returns a plain dict with all field keys."""
+    record = DocumentRecord(
+        id="doc_abc123",
+        name="invoice.pdf",
+        path="baskets/inv/invoice.pdf",
+        content_type=None,
+        document_type="file",
+        size=None,
+        checksum="deadbeef" * 8,
+        status="active",
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+    dumped = record.model_dump()
+
+    assert isinstance(dumped, dict)
+    assert set(dumped.keys()) == {
+        "id",
+        "name",
+        "path",
+        "content_type",
+        "document_type",
+        "size",
+        "checksum",
+        "status",
+        "created_at",
+        "updated_at",
+    }
+    assert dumped["id"] == "doc_abc123"
+    assert dumped["content_type"] is None
+    assert dumped["size"] is None


### PR DESCRIPTION
## Problem
The lightweight metadata APIs return raw dicts. This makes the API 
shape unstable for library consumers like llamasee-meta. Dict access 
has no type checking, no IDE support, and no contract enforcement.

## Solution
Added BasketRecord and DocumentRecord as frozen Pydantic v2 models. 
Frozen models enforce the read-only contract at runtime.

## Changes
- docex/models/records.py: new file with both models
- docex/docCore.py: list_baskets_with_metadata returns List[BasketRecord]
- docex/document.py: get_details returns DocumentRecord
- docex/__init__.py: both models exported from public API
- tests/test_records.py: 8 new tests covering instantiation, frozen 
  enforcement, return types, and model_dump compatibility
- call sites in tests and scripts updated to attribute access

## Design Decision
Used Pydantic BaseModel with frozen=True over stdlib dataclasses 
because Pydantic is already a declared core dependency, provides 
built-in .model_dump() for backward-compatible dict conversion, 
and gives consumers IDE completion and runtime validation for free.

## Testing

Full suite before: 108 passing, 80 failed, 22 errors
Full suite after: 116 passing, 80 failed, 22 errors

8 new tests all pass. The pre-existing failures are unchanged and 
unrelated to this change, mostly requiring a running Postgres instance 
or environment variables not set in CI.