### PR TITLE
Update Python 3.13 runtime requirements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install build tools
         run: |
           pip install build
@@ -24,4 +24,4 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload dist/* 
+        run: twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 # Core dependencies - minimal set required for basic document management
 dependencies = [
     "sqlalchemy>=2.0.0",
@@ -76,9 +76,9 @@ dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "moto>=4.0.0",  # For mocking AWS services in tests
-    "black>=22.0.0",
+    "black>=25.1.0",
     "isort>=5.0.0",
-    "mypy>=0.900",
+    "mypy>=1.15.0",
     "ruff>=0.11.0",
 ]
 
@@ -93,7 +93,7 @@ profile = "black"
 line_length = 88
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.13"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
@@ -101,7 +101,7 @@ disallow_incomplete_defs = true
 
 [tool.ruff]
 line-length = 88
-target-version = "py311"
+target-version = "py313"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Summary
- require Python 3.13 in package/runtime/build configuration where this repo declares Python
- update CI/build runners and generated package templates to use Python 3.13 where applicable
- include pending branch-local changes already present in the working tree

## Validation
- workspace audit checked 32 active pyproject.toml files with 0 non-3.13 requires-python values
- active GitHub workflow/runtime scan found no old Python runner pins
- git diff --check passed across dirty repos before committing
