### PR TITLE
Add configurable field extraction with rules-first and optional LLM f…

### DIFF
--- a/docex/extraction/__init__.py
+++ b/docex/extraction/__init__.py
@@ -1,0 +1,34 @@
+"""
+Configurable field extraction for DocEX documents.
+
+Fields are declared as label phrases plus a type (money, date, text) -- see
+:mod:`docex.extraction.config`. A rules tier finds and validates values for
+free; an optional caller-provided LLM handles only the fields the rules miss.
+Results are stored as document metadata with full traceability of how each
+value was found.
+"""
+
+from docex.extraction.config import ExtractionConfig, FieldSpec
+from docex.extraction.engine import (
+    CONFLICT,
+    FOUND,
+    NOT_FOUND,
+    FieldResult,
+    RulesEngine,
+)
+from docex.extraction.llm import LLMFn, build_prompt, extract_missing
+from docex.extraction.processor import FieldExtractionProcessor
+
+__all__ = [
+    'ExtractionConfig',
+    'FieldSpec',
+    'FieldResult',
+    'RulesEngine',
+    'FieldExtractionProcessor',
+    'LLMFn',
+    'build_prompt',
+    'extract_missing',
+    'FOUND',
+    'NOT_FOUND',
+    'CONFLICT',
+]

--- a/docex/extraction/config.py
+++ b/docex/extraction/config.py
@@ -1,0 +1,79 @@
+"""
+Configuration for field extraction.
+
+Users declare the fields they want extracted as plain phrases and a type --
+no regular expressions required:
+
+    fields:
+      total:
+        type: money
+        labels: ["Total Due", "Amount Due", "Balance Due"]
+
+A default configuration for commercial real estate invoices ships with the
+package (``cre_invoice_fields.yaml``) and is used when no configuration is
+provided. Every part of it can be overridden by passing a dict or a YAML file.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import yaml
+
+FIELD_TYPES = ('money', 'date', 'text')
+
+_DEFAULT_CONFIG_PATH = Path(__file__).parent / 'cre_invoice_fields.yaml'
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    """One field to extract: its name, value type, and the label phrases that identify it."""
+
+    name: str
+    type: str
+    labels: Tuple[str, ...]
+
+    def __post_init__(self):
+        if self.type not in FIELD_TYPES:
+            raise ValueError(
+                f"Field '{self.name}' has invalid type '{self.type}'. "
+                f"Must be one of: {', '.join(FIELD_TYPES)}"
+            )
+        if not self.labels:
+            raise ValueError(f"Field '{self.name}' must define at least one label phrase")
+
+
+class ExtractionConfig:
+    """The set of fields to extract from a document."""
+
+    def __init__(self, fields: List[FieldSpec]):
+        if not fields:
+            raise ValueError("ExtractionConfig requires at least one field")
+        self.fields = list(fields)
+
+    @classmethod
+    def from_dict(cls, fields: Dict[str, Any]) -> 'ExtractionConfig':
+        """Build from a dict shaped like {'total': {'type': 'money', 'labels': [...]}}."""
+        specs = [
+            FieldSpec(
+                name=name,
+                type=definition.get('type', 'text'),
+                labels=tuple(definition.get('labels', ())),
+            )
+            for name, definition in fields.items()
+        ]
+        return cls(specs)
+
+    @classmethod
+    def from_yaml(cls, path: str) -> 'ExtractionConfig':
+        """Build from a YAML file with a top-level ``fields`` mapping."""
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, dict) or 'fields' not in data:
+            raise ValueError(f"Extraction config file {path} must contain a 'fields' mapping")
+        return cls.from_dict(data['fields'])
+
+    @classmethod
+    def default(cls) -> 'ExtractionConfig':
+        """The packaged default field set for commercial real estate invoices."""
+        return cls.from_yaml(str(_DEFAULT_CONFIG_PATH))

--- a/docex/extraction/cre_invoice_fields.yaml
+++ b/docex/extraction/cre_invoice_fields.yaml
@@ -1,0 +1,27 @@
+# Default extraction fields for commercial real estate invoices.
+# Override by passing your own dict or YAML file to ExtractionConfig.
+fields:
+  invoice_number:
+    type: text
+    labels: ["Invoice No.", "Invoice Number", "Invoice #"]
+  invoice_date:
+    type: date
+    labels: ["Invoice Date", "Date"]
+  due_date:
+    type: date
+    labels: ["Due Date", "Payment Due"]
+  vendor:
+    type: text
+    labels: ["Remit To", "Vendor", "Landlord", "Property Manager"]
+  total:
+    type: money
+    labels: ["Total Due", "Amount Due", "Balance Due", "Total"]
+  base_rent:
+    type: money
+    labels: ["Base Rent", "Minimum Rent"]
+  cam:
+    type: money
+    labels: ["CAM", "Common Area Maintenance", "Operating Expenses"]
+  tax:
+    type: money
+    labels: ["Real Estate Tax", "Property Tax", "Tax"]

--- a/docex/extraction/engine.py
+++ b/docex/extraction/engine.py
@@ -1,0 +1,196 @@
+"""
+Rules tier: label-based field extraction with type validation.
+
+For each configured field the engine scans the document text for any of the
+field's label phrases and takes the nearest value of the declared type --
+first on the same line after the label, then on the next non-empty line
+(invoices often print the label above the value).
+
+Values must parse cleanly for their type (real number, real calendar date) or
+the candidate is rejected, so a scanner artifact like "$12,5OO" is never
+stored as a total. If different labels produce different valid values for the
+same field, the field is marked conflicting instead of silently picking one.
+"""
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from typing import Dict, List, Optional, Tuple
+
+from docex.extraction.config import ExtractionConfig, FieldSpec
+
+# Field result statuses
+FOUND = 'found'
+NOT_FOUND = 'not_found'
+CONFLICT = 'conflict'
+
+# Extraction sources
+SOURCE_RULES = 'regex'
+SOURCE_LLM = 'llm'
+
+_MONEY_RE = re.compile(r'\(?\$?\s?-?\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?\)?')
+
+_DATE_RES = (
+    re.compile(r'\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b'),
+    re.compile(r'\b\d{4}-\d{1,2}-\d{1,2}\b'),
+    re.compile(r'\b[A-Za-z]{3,9}\.? \d{1,2},? \d{4}\b'),
+)
+
+_DATE_FORMATS = (
+    '%m/%d/%Y', '%m/%d/%y', '%m-%d-%Y', '%m-%d-%y', '%Y-%m-%d',
+    '%B %d, %Y', '%B %d %Y', '%b %d, %Y', '%b %d %Y',
+)
+
+_MAX_TEXT_LENGTH = 120
+
+
+@dataclass
+class FieldResult:
+    """Outcome of extracting one field."""
+
+    name: str
+    status: str
+    value: Optional[str] = None
+    label: Optional[str] = None
+    source: Optional[str] = None
+
+
+def parse_money(raw: str) -> Optional[str]:
+    """Normalize a money string to a plain decimal, or None if it is not a valid amount."""
+    cleaned = raw.strip().replace('$', '').replace(',', '').replace(' ', '')
+    negative = cleaned.startswith('(') and cleaned.endswith(')')
+    if negative:
+        cleaned = cleaned[1:-1]
+    try:
+        amount = Decimal(cleaned)
+    except InvalidOperation:
+        return None
+    return str(-amount if negative else amount)
+
+
+def parse_date(raw: str) -> Optional[str]:
+    """Normalize a date string to YYYY-MM-DD, or None if it is not a real date."""
+    cleaned = raw.strip().replace('.', '')
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(cleaned, fmt).date().isoformat()
+        except ValueError:
+            continue
+    return None
+
+
+def parse_text(raw: str) -> Optional[str]:
+    """Clean a free-text value; reject empty or implausibly long grabs."""
+    cleaned = raw.strip(' \t:#-\u2013\u2014.').strip()
+    if not cleaned or len(cleaned) > _MAX_TEXT_LENGTH:
+        return None
+    return cleaned
+
+
+def normalize_value(field_type: str, raw: str) -> Optional[str]:
+    """Validate and normalize a raw value for the given field type."""
+    if field_type == 'money':
+        return _first_valid(_money_candidates(raw), parse_money)
+    if field_type == 'date':
+        candidates = [m.group(0) for rx in _DATE_RES for m in rx.finditer(raw)]
+        return _first_valid(candidates, parse_date)
+    return parse_text(raw)
+
+
+def _money_candidates(segment: str):
+    """Money-looking matches with clean boundaries.
+
+    A match glued to letters or to malformed digit groups (e.g. the "$12"
+    inside a scanner-garbled "$12,5OO") is rejected rather than returning a
+    wrong amount.
+    """
+    for m in _MONEY_RE.finditer(segment):
+        start, end = m.span()
+        if start > 0 and segment[start - 1].isalnum():
+            continue
+        if end < len(segment):
+            following = segment[end]
+            if following.isalnum():
+                continue
+            if following in ',.' and end + 1 < len(segment) and not segment[end + 1].isspace():
+                continue
+        yield m.group(0)
+
+
+def _first_valid(candidates, parser) -> Optional[str]:
+    for candidate in candidates:
+        value = parser(candidate)
+        if value is not None:
+            return value
+    return None
+
+
+class RulesEngine:
+    """Extracts configured fields from text using label phrases and type validation."""
+
+    def __init__(self, config: ExtractionConfig):
+        self.config = config
+
+    def extract(self, text: str) -> Dict[str, FieldResult]:
+        """Extract every configured field. Returns a result per field, found or not."""
+        lines = text.splitlines()
+        candidates: Dict[str, List[Tuple[str, str]]] = {spec.name: [] for spec in self.config.fields}
+
+        for index, line in enumerate(lines):
+            for start, end, spec, label in self._label_matches(line):
+                value = self._value_near(spec.type, line[end:], self._next_nonempty(lines, index))
+                if value is not None:
+                    candidates[spec.name].append((value, label))
+
+        results = {}
+        for spec in self.config.fields:
+            found = candidates[spec.name]
+            distinct = {value for value, _ in found}
+            if not found:
+                results[spec.name] = FieldResult(spec.name, NOT_FOUND)
+            elif len(distinct) == 1:
+                value, label = found[0]
+                results[spec.name] = FieldResult(spec.name, FOUND, value, label, SOURCE_RULES)
+            else:
+                results[spec.name] = FieldResult(spec.name, CONFLICT)
+        return results
+
+    def _label_matches(self, line: str) -> List[Tuple[int, int, FieldSpec, str]]:
+        """All label occurrences in a line, at word boundaries.
+
+        A shorter label contained inside a longer one is suppressed, so a
+        configured "Due Date" wins over a configured "Date" on the same span.
+        """
+        matches = []
+        for spec in self.config.fields:
+            for label in spec.labels:
+                for m in re.finditer(re.escape(label), line, re.IGNORECASE):
+                    start, end = m.span()
+                    if start > 0 and line[start - 1].isalnum():
+                        continue
+                    if end < len(line) and line[end].isalnum():
+                        continue
+                    matches.append((start, end, spec, label))
+
+        return [
+            m for m in matches
+            if not any(
+                o is not m and o[0] <= m[0] and m[1] <= o[1] and (o[1] - o[0]) > (m[1] - m[0])
+                for o in matches
+            )
+        ]
+
+    @staticmethod
+    def _value_near(field_type: str, same_line: str, next_line: Optional[str]) -> Optional[str]:
+        value = normalize_value(field_type, same_line)
+        if value is None and next_line is not None:
+            value = normalize_value(field_type, next_line)
+        return value
+
+    @staticmethod
+    def _next_nonempty(lines: List[str], index: int) -> Optional[str]:
+        for line in lines[index + 1:]:
+            if line.strip():
+                return line
+        return None

--- a/docex/extraction/llm.py
+++ b/docex/extraction/llm.py
@@ -1,0 +1,92 @@
+"""
+Fallback tier: LLM extraction for fields the rules missed.
+
+The caller supplies a plain callable (``llm_fn``) that maps a prompt string to
+a response string, following the same bring-your-own-provider pattern DocEX
+uses for embedding functions. The package contains no provider SDK and makes
+no network calls of its own.
+
+The prompt is built from the same :class:`ExtractionConfig` the rules tier
+uses: only configured fields are requested, the configured label phrases are
+given as hints, and the model is told to also consider synonyms,
+abbreviations, and acronyms of those phrases. For traceability the model must
+return, per field, the exact label text as printed in the document; a value
+whose claimed label does not actually appear in the text is rejected, and
+every accepted value passes the same type validation as the rules tier.
+"""
+
+import json
+import re
+from typing import Callable, Dict, List
+
+from docex.extraction.engine import FOUND, SOURCE_LLM, FieldResult, normalize_value
+from docex.extraction.config import FieldSpec
+
+LLMFn = Callable[[str], str]
+
+_JSON_BLOCK = re.compile(r'\{.*\}', re.DOTALL)
+
+
+def build_prompt(text: str, specs: List[FieldSpec]) -> str:
+    """Build the extraction prompt for the fields the rules tier could not find."""
+    field_lines = '\n'.join(
+        f"- {spec.name} (type: {spec.type}), usually labelled: {', '.join(spec.labels)}"
+        for spec in specs
+    )
+    return (
+        "Extract the following fields from the document text below.\n"
+        "The fields may appear under different wording than the labels listed, "
+        "including synonyms, abbreviations, or acronyms (for example 'Tot' or "
+        "'Amt Due' for a total). Search for those variations too.\n\n"
+        "Return ONLY minified JSON, no prose, in exactly this shape:\n"
+        '{"fields": {"<field_name>": {"value": "<value>", "label": "<label text exactly as printed>"}}}\n'
+        "Use null for any field you cannot find. The label must be copied "
+        "character-for-character from the document text.\n\n"
+        f"Fields to extract:\n{field_lines}\n\n"
+        f"Document text:\n{text}"
+    )
+
+
+def extract_missing(llm_fn: LLMFn, text: str, specs: List[FieldSpec]) -> Dict[str, FieldResult]:
+    """Ask the LLM for the given fields. Returns results only for verified finds.
+
+    A field is accepted only if the model returned both a value and a label,
+    the label actually occurs in the document text, and the value passes the
+    field's type validation. Everything else stays missing.
+    """
+    if not specs:
+        return {}
+
+    response = llm_fn(build_prompt(text, specs))
+    if not isinstance(response, str):
+        raise ValueError("llm_fn must return a string response")
+
+    match = _JSON_BLOCK.search(response)
+    if not match:
+        return {}
+    try:
+        data = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return {}
+
+    fields = data.get('fields')
+    if not isinstance(fields, dict):
+        return {}
+
+    lowered_text = text.lower()
+    results: Dict[str, FieldResult] = {}
+    for spec in specs:
+        entry = fields.get(spec.name)
+        if not isinstance(entry, dict):
+            continue
+        value, label = entry.get('value'), entry.get('label')
+        if value in (None, '') or not isinstance(label, str) or not label.strip():
+            continue
+        if label.strip().lower() not in lowered_text:
+            # The model claimed a label that is not in the document; do not trust the value.
+            continue
+        normalized = normalize_value(spec.type, str(value))
+        if normalized is None:
+            continue
+        results[spec.name] = FieldResult(spec.name, FOUND, normalized, label.strip(), SOURCE_LLM)
+    return results

--- a/docex/extraction/processor.py
+++ b/docex/extraction/processor.py
@@ -1,0 +1,134 @@
+"""
+DocEX processor that extracts configured fields and saves them as metadata.
+
+For every field that is found, three metadata rows are written so the result
+is fully traceable:
+
+    total                12500.00
+    total_source         regex          (or: llm)
+    total_source_label   Total Due      (the label text that identified it)
+
+One additional row, ``needs_review``, is 'true' whenever any configured field
+is missing or produced conflicting values -- a single metadata search then
+returns every document that a person should look at.
+"""
+
+import io
+import logging
+from typing import Any, Dict, Optional
+
+from docex.db.connection import Database
+from docex.document import Document
+from docex.extraction.config import ExtractionConfig
+from docex.extraction.engine import FOUND, NOT_FOUND, FieldResult, RulesEngine
+from docex.extraction.llm import LLMFn, extract_missing
+from docex.processors.base import BaseProcessor, ProcessingResult
+from docex.services.metadata_service import MetadataService
+
+logger = logging.getLogger(__name__)
+
+
+class FieldExtractionProcessor(BaseProcessor):
+    """Extracts configured fields from a document and stores them as metadata."""
+
+    def __init__(
+        self,
+        config: Optional[Dict[str, Any]] = None,
+        db: Optional[Database] = None,
+        extraction_config: Optional[ExtractionConfig] = None,
+        llm_fn: Optional[LLMFn] = None,
+    ):
+        """
+        Args:
+            config: Standard processor config dict. May contain 'fields' (inline
+                field definitions) or 'config_file' (path to a YAML config).
+            db: Optional tenant-aware database instance.
+            extraction_config: Explicit ExtractionConfig; takes precedence over
+                anything in ``config``. Defaults to the packaged CRE invoice set.
+            llm_fn: Optional callable mapping a prompt string to a response
+                string. When provided, fields the rules tier cannot find are
+                requested from it in a single call per document.
+        """
+        super().__init__(config or {}, db)
+        if extraction_config is not None:
+            self.extraction_config = extraction_config
+        elif self.config.get('fields'):
+            self.extraction_config = ExtractionConfig.from_dict(self.config['fields'])
+        elif self.config.get('config_file'):
+            self.extraction_config = ExtractionConfig.from_yaml(self.config['config_file'])
+        else:
+            self.extraction_config = ExtractionConfig.default()
+        self.llm_fn = llm_fn
+        self.engine = RulesEngine(self.extraction_config)
+
+    def can_process(self, document: Document) -> bool:
+        return document.name.lower().endswith(('.pdf', '.txt', '.text', '.md'))
+
+    def read_text(self, document: Document) -> str:
+        """Get the document's text (PDF via pdfminer, everything else as stored text).
+
+        This performs no database writes, so it is safe to call from worker threads.
+        """
+        if document.name.lower().endswith('.pdf'):
+            try:
+                from pdfminer.high_level import extract_text
+            except ImportError:
+                raise ImportError(
+                    "PDF extraction requires 'pdfminer.six'. Install it with: pip install docex[pdf]"
+                )
+            return extract_text(io.BytesIO(self.get_document_bytes(document)))
+        return self.get_document_text(document)
+
+    def extract_from_text(self, text: str) -> Dict[str, FieldResult]:
+        """Run the rules tier, then the LLM fallback for whatever is still missing.
+
+        This performs no database writes, so it is safe to call from worker threads.
+        """
+        results = self.engine.extract(text)
+        if self.llm_fn:
+            missing = [
+                spec for spec in self.extraction_config.fields
+                if results[spec.name].status == NOT_FOUND
+            ]
+            results.update(extract_missing(self.llm_fn, text, missing))
+        return results
+
+    @staticmethod
+    def build_metadata(results: Dict[str, FieldResult]) -> Dict[str, str]:
+        """Convert field results into the metadata rows to store."""
+        metadata: Dict[str, str] = {}
+        needs_review = False
+        for result in results.values():
+            if result.status == FOUND:
+                metadata[result.name] = result.value
+                metadata[f'{result.name}_source'] = result.source
+                metadata[f'{result.name}_source_label'] = result.label
+            else:
+                needs_review = True
+        metadata['needs_review'] = 'true' if needs_review else 'false'
+        return metadata
+
+    def save_results(self, document: Document, results: Dict[str, FieldResult]) -> Dict[str, str]:
+        """Write extraction results to document metadata and record the operation."""
+        metadata = self.build_metadata(results)
+        MetadataService(self.db).update_metadata(document.id, metadata)
+        self._record_operation(document, 'success', output_metadata=metadata)
+        return metadata
+
+    def process(self, document: Document, text: Optional[str] = None) -> ProcessingResult:
+        """Extract fields from the document and save them as metadata.
+
+        Args:
+            document: Document to process.
+            text: Optional pre-extracted document text; when provided the
+                document content is not read again.
+        """
+        try:
+            if text is None:
+                text = self.read_text(document)
+            results = self.extract_from_text(text)
+            metadata = self.save_results(document, results)
+            return ProcessingResult(success=True, content=text, metadata=metadata)
+        except Exception as e:
+            logger.error(f"Field extraction failed for document {document.id}: {e}")
+            return ProcessingResult(success=False, error=str(e))

--- a/examples/field_extraction_example.py
+++ b/examples/field_extraction_example.py
@@ -1,0 +1,69 @@
+"""
+Example: Configurable field extraction with traceable results.
+
+Adds the sample invoice PDF to a basket, extracts the fields defined in a
+config (label phrases + type, no regular expressions required), and stores
+each found value as document metadata together with how it was found:
+
+    total                12500.00
+    total_source         regex        (or: llm)
+    total_source_label   Total Due    (the label text that identified it)
+    needs_review         true/false   (any field missing or conflicting)
+
+The extraction runs rules-first. To resolve fields whose labels are worded
+unexpectedly (abbreviations, synonyms), pass an llm_fn callable:
+
+    def my_llm(prompt: str) -> str:
+        return my_provider.complete(prompt)   # returns the model's JSON reply
+
+    processor = FieldExtractionProcessor(llm_fn=my_llm)
+
+Note: DocEX must be initialized first using the CLI command 'docex init'.
+Requires the pdf extra for the sample PDF: pip install docex[pdf]
+"""
+
+import logging
+import sys
+
+from docex import DocEX
+from docex.context import UserContext
+from docex.extraction import ExtractionConfig, FieldExtractionProcessor
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Fields to extract: plain phrases and a type. Fully user-definable;
+# omit this to use the packaged commercial real estate default set.
+FIELDS = {
+    'invoice_number': {'type': 'text', 'labels': ['Invoice No.', 'Invoice Number']},
+    'invoice_date': {'type': 'date', 'labels': ['Invoice Date', 'Date']},
+    'po_number': {'type': 'text', 'labels': ['PO number', 'Purchase Order']},
+    'total': {'type': 'money', 'labels': ['Total Due', 'Amount Due', 'Total']},
+}
+
+
+def main():
+    user_context = UserContext(user_id='extraction_example', user_email='example@example.com')
+    docEX = DocEX(user_context=user_context)
+    basket = docEX.basket('extraction_example')
+
+    doc = basket.add('examples/sample_data/invoice_2001321.pdf', metadata={'biz_doc_type': 'invoice'})
+    logger.info(f"Added document {doc.id}")
+
+    processor = FieldExtractionProcessor(extraction_config=ExtractionConfig.from_dict(FIELDS))
+    result = processor.process(doc)
+    if not result.success:
+        logger.error(f"Extraction failed: {result.error}")
+        sys.exit(1)
+
+    logger.info("Stored metadata:")
+    for key, value in sorted(doc.get_metadata().items()):
+        logger.info(f"  {key} = {value}")
+
+    # The stored fields are immediately searchable.
+    flagged = basket.find_documents_by_metadata({'needs_review': 'true'})
+    logger.info(f"Documents needing review in this basket: {len(flagged)}")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/extraction/conftest.py
+++ b/tests/extraction/conftest.py
@@ -1,0 +1,30 @@
+"""Sandboxed DocEX environment for extraction integration tests.
+
+DOCEX_HOME is pointed at a temporary directory before docex is imported, so
+these tests never touch a real ~/.docex configuration or database.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_SANDBOX = Path(tempfile.mkdtemp(prefix='docex_extraction_tests_'))
+os.environ['DOCEX_HOME'] = str(_SANDBOX)
+
+
+@pytest.fixture(scope='session')
+def docex_instance():
+    from docex import DocEX
+
+    DocEX.setup(
+        database={'type': 'sqlite', 'sqlite': {'path': str(_SANDBOX / 'docex.db')}},
+        storage={'type': 'filesystem', 'filesystem': {'path': str(_SANDBOX / 'storage')}},
+    )
+    return DocEX()
+
+
+@pytest.fixture(scope='session')
+def basket(docex_instance):
+    return docex_instance.basket('extraction_test_basket')

--- a/tests/extraction/test_engine.py
+++ b/tests/extraction/test_engine.py
@@ -1,0 +1,88 @@
+"""Rules engine: label matching, type validation, normalization, conflicts."""
+
+from docex.extraction.config import ExtractionConfig
+from docex.extraction.engine import CONFLICT, FOUND, NOT_FOUND, RulesEngine
+
+
+def make_engine(fields):
+    return RulesEngine(ExtractionConfig.from_dict(fields))
+
+
+def test_value_on_same_line():
+    engine = make_engine({'total': {'type': 'money', 'labels': ['Total Due']}})
+    results = engine.extract("Invoice\nTotal Due: $12,500.00\nThank you")
+    assert results['total'].status == FOUND
+    assert results['total'].value == '12500.00'
+    assert results['total'].label == 'Total Due'
+    assert results['total'].source == 'regex'
+
+
+def test_value_on_next_line():
+    engine = make_engine({'total': {'type': 'money', 'labels': ['Amount Due']}})
+    results = engine.extract("Amount Due\n$3,200.50")
+    assert results['total'].status == FOUND
+    assert results['total'].value == '3200.50'
+
+
+def test_conflicting_values_flagged_not_guessed():
+    engine = make_engine({'total': {'type': 'money', 'labels': ['Total Due', 'Balance Due']}})
+    results = engine.extract("Total Due: $100.00\nBalance Due: $200.00")
+    assert results['total'].status == CONFLICT
+    assert results['total'].value is None
+
+
+def test_same_value_under_two_labels_is_not_a_conflict():
+    engine = make_engine({'total': {'type': 'money', 'labels': ['Total Due', 'Balance Due']}})
+    results = engine.extract("Total Due: $100.00\nBalance Due: $100.00")
+    assert results['total'].status == FOUND
+    assert results['total'].value == '100.00'
+
+
+def test_garbled_money_rejected():
+    # Scanner artifact: letter O instead of zeros. Must not be stored as a number.
+    engine = make_engine({'total': {'type': 'money', 'labels': ['Total Due']}})
+    results = engine.extract("Total Due: $12,5OO")
+    assert results['total'].status == NOT_FOUND
+
+
+def test_date_normalized_to_iso():
+    engine = make_engine({'invoice_date': {'type': 'date', 'labels': ['Invoice Date']}})
+    results = engine.extract("Invoice Date: 07/03/2025")
+    assert results['invoice_date'].value == '2025-07-03'
+
+
+def test_impossible_date_rejected():
+    engine = make_engine({'invoice_date': {'type': 'date', 'labels': ['Invoice Date']}})
+    results = engine.extract("Invoice Date: 13/45/2025")
+    assert results['invoice_date'].status == NOT_FOUND
+
+
+def test_label_requires_word_boundary():
+    # "Subtotal" must not match the label "Total".
+    engine = make_engine({'total': {'type': 'money', 'labels': ['Total']}})
+    results = engine.extract("Subtotal: $99.00\nTotal: $150.00")
+    assert results['total'].status == FOUND
+    assert results['total'].value == '150.00'
+
+
+def test_longer_label_wins_on_same_span():
+    # "Due Date" (due_date) must suppress "Date" (invoice_date) on its line.
+    engine = make_engine({
+        'invoice_date': {'type': 'date', 'labels': ['Date']},
+        'due_date': {'type': 'date', 'labels': ['Due Date']},
+    })
+    results = engine.extract("Due Date: 08/01/2025\nDate: 07/03/2025")
+    assert results['due_date'].value == '2025-08-01'
+    assert results['invoice_date'].status == FOUND
+    assert results['invoice_date'].value == '2025-07-03'
+
+
+def test_text_field_extracted_and_missing_field_reported():
+    engine = make_engine({
+        'vendor': {'type': 'text', 'labels': ['Remit To']},
+        'cam': {'type': 'money', 'labels': ['CAM']},
+    })
+    results = engine.extract("Remit To: Acme Property Management LLC")
+    assert results['vendor'].status == FOUND
+    assert results['vendor'].value == 'Acme Property Management LLC'
+    assert results['cam'].status == NOT_FOUND

--- a/tests/extraction/test_llm.py
+++ b/tests/extraction/test_llm.py
@@ -1,0 +1,71 @@
+"""LLM fallback tier, tested with fake llm_fn callables (no network, no keys)."""
+
+import json
+
+import pytest
+
+from docex.extraction.config import ExtractionConfig
+from docex.extraction.llm import build_prompt, extract_missing
+
+SPECS = ExtractionConfig.from_dict({
+    'total': {'type': 'money', 'labels': ['Total Due', 'Amount Due']},
+    'vendor': {'type': 'text', 'labels': ['Remit To']},
+}).fields
+
+TEXT = "Acme Property Management LLC\nTot: $12,500.00\nThank you for your business"
+
+
+def fake_llm(response):
+    """Build a fake llm_fn returning a canned response, recording the prompt it got."""
+    calls = []
+
+    def llm_fn(prompt):
+        calls.append(prompt)
+        return response
+
+    llm_fn.calls = calls
+    return llm_fn
+
+
+def test_accepts_value_with_verified_label():
+    # The model matched the abbreviation "Tot" -- present in the text, so trusted.
+    llm = fake_llm(json.dumps({'fields': {'total': {'value': '$12,500.00', 'label': 'Tot'}}}))
+    results = extract_missing(llm, TEXT, [SPECS[0]])
+    assert results['total'].value == '12500.00'
+    assert results['total'].source == 'llm'
+    assert results['total'].label == 'Tot'
+
+
+def test_rejects_value_whose_label_is_not_in_document():
+    llm = fake_llm(json.dumps({'fields': {'total': {'value': '999.99', 'label': 'Grand Total'}}}))
+    assert extract_missing(llm, TEXT, [SPECS[0]]) == {}
+
+
+def test_rejects_value_failing_type_validation():
+    llm = fake_llm(json.dumps({'fields': {'total': {'value': 'twelve thousand', 'label': 'Tot'}}}))
+    assert extract_missing(llm, TEXT, [SPECS[0]]) == {}
+
+
+def test_null_and_garbage_responses_yield_nothing():
+    assert extract_missing(fake_llm(json.dumps({'fields': {'total': None}})), TEXT, [SPECS[0]]) == {}
+    assert extract_missing(fake_llm('not json at all'), TEXT, [SPECS[0]]) == {}
+
+
+def test_no_call_made_when_nothing_is_missing():
+    llm = fake_llm('{}')
+    assert extract_missing(llm, TEXT, []) == {}
+    assert llm.calls == []
+
+
+def test_prompt_contains_only_requested_fields_with_labels_and_types():
+    prompt = build_prompt(TEXT, [SPECS[0]])
+    assert 'total' in prompt and 'money' in prompt
+    assert 'Total Due' in prompt and 'Amount Due' in prompt
+    assert 'vendor' not in prompt
+    assert 'abbreviation' in prompt  # synonym/abbreviation/acronym instruction present
+    assert TEXT in prompt
+
+
+def test_non_string_response_raises():
+    with pytest.raises(ValueError):
+        extract_missing(lambda prompt: 12345, TEXT, [SPECS[0]])

--- a/tests/extraction/test_processor.py
+++ b/tests/extraction/test_processor.py
@@ -1,0 +1,94 @@
+"""End-to-end: add a document, run the processor, verify the stored metadata."""
+
+import json
+
+from docex.extraction.config import ExtractionConfig
+from docex.extraction.processor import FieldExtractionProcessor
+
+FIELDS = {
+    'invoice_number': {'type': 'text', 'labels': ['Invoice No.']},
+    'invoice_date': {'type': 'date', 'labels': ['Invoice Date']},
+    'total': {'type': 'money', 'labels': ['Total Due', 'Amount Due']},
+    'vendor': {'type': 'text', 'labels': ['Remit To']},
+}
+
+CLEAN_INVOICE = """ACME PROPERTY MANAGEMENT LLC
+Invoice No.: 2024-0042
+Invoice Date: 07/03/2025
+Remit To: Acme Property Management LLC
+Total Due: $12,500.00
+"""
+
+# 'Tot' is not a configured label; only the LLM fallback can resolve the total.
+ABBREVIATED_INVOICE = """ACME PROPERTY MANAGEMENT LLC
+Invoice No.: 2024-0043
+Invoice Date: 07/04/2025
+Remit To: Acme Property Management LLC
+Tot: $9,100.00
+"""
+
+
+def add_document(basket, tmp_path, name, content):
+    file_path = tmp_path / name
+    file_path.write_text(content)
+    return basket.add(str(file_path))
+
+
+def make_processor(**kwargs):
+    return FieldExtractionProcessor(
+        extraction_config=ExtractionConfig.from_dict(FIELDS), **kwargs
+    )
+
+
+def test_rules_only_document_fully_extracted(basket, tmp_path):
+    doc = add_document(basket, tmp_path, 'clean_invoice.txt', CLEAN_INVOICE)
+    result = make_processor().process(doc)
+
+    assert result.success
+    metadata = doc.get_metadata()
+    assert metadata['invoice_number'] == '2024-0042'
+    assert metadata['invoice_date'] == '2025-07-03'
+    assert metadata['total'] == '12500.00'
+    assert metadata['vendor'] == 'Acme Property Management LLC'
+    assert metadata['total_source'] == 'regex'
+    assert metadata['total_source_label'] == 'Total Due'
+    assert metadata['needs_review'] == 'false'
+
+
+def test_llm_fallback_used_only_for_missing_fields(basket, tmp_path):
+    doc = add_document(basket, tmp_path, 'abbreviated_invoice.txt', ABBREVIATED_INVOICE)
+
+    requested = []
+
+    def fake_llm(prompt):
+        requested.append(prompt)
+        return json.dumps({'fields': {'total': {'value': '$9,100.00', 'label': 'Tot'}}})
+
+    result = make_processor(llm_fn=fake_llm).process(doc)
+
+    assert result.success
+    metadata = doc.get_metadata()
+    assert metadata['total'] == '9100.00'
+    assert metadata['total_source'] == 'llm'
+    assert metadata['total_source_label'] == 'Tot'
+    assert metadata['needs_review'] == 'false'
+    # Exactly one LLM call, asking only for the field the rules missed.
+    assert len(requested) == 1
+    assert 'total' in requested[0]
+    assert 'invoice_number' not in requested[0]
+
+
+def test_missing_field_flags_document_for_review(basket, tmp_path):
+    doc = add_document(basket, tmp_path, 'incomplete_invoice.txt', ABBREVIATED_INVOICE)
+    # No LLM provided: the abbreviated total cannot be resolved by rules.
+    result = make_processor().process(doc)
+
+    assert result.success
+    metadata = doc.get_metadata()
+    assert 'total' not in metadata
+    assert metadata['needs_review'] == 'true'
+
+
+def test_flagged_documents_findable_by_metadata_search(basket, tmp_path):
+    matches = basket.find_documents_by_metadata({'needs_review': 'true'})
+    assert any(m.name == 'incomplete_invoice.txt' for m in matches)


### PR DESCRIPTION
…allback

New docex/extraction module: fields are declared as label phrases plus a type (money, date, text) in a dict or YAML config; a rules engine finds and type-validates values (same line, then next line), flags conflicting values instead of guessing, and an optional caller-provided llm_fn resolves only the fields the rules miss. Every stored value carries its source and the exact label text that identified it, and documents with missing or conflicting fields are flagged needs_review for metadata search. Includes a default CRE invoice field set, unit and integration tests, and an example.